### PR TITLE
Removing word wrap. Setting max-width to 400px.

### DIFF
--- a/ext/content/inject.css
+++ b/ext/content/inject.css
@@ -1,6 +1,6 @@
 .css-truncate.css-truncate-target {
     white-space: normal !important;
-    word-wrap: break-word !important;
+    max-width: 400px !important;
 }
 
 form#new_issue div.column.main {


### PR DESCRIPTION
Per Github Styleguide (https://github.com/styleguide/css/9.0) on CSS: "The maximum width of the truncated text can be changed by overriding the max-width of the .css-truncate-target".

Instead of word-wrapping, I set the width to a (reasonable) amount. This indeed solves the problem, as described in issue #6.
