### PR TITLE
Avoid dashboard sidebar moving under the content

### DIFF
--- a/src/github-inject.less
+++ b/src/github-inject.less
@@ -29,10 +29,6 @@
     max-width: inherit !important;
 }
 
-& .dashboard-sidebar {
-    width: 500px !important;
-}
-
 .ruleset(@breakpoint) {
     .width(@width) {
         width: @breakpoint - @width !important
@@ -133,6 +129,10 @@
             padding-left: 0 !important;
             padding-right: 0 !important;
         }
+    }
+    
+    & .dashboard-sidebar {
+        width: 500px !important;
     }
 }
 


### PR DESCRIPTION
I have one screen in vertical mode (With width = 1080px) and the extension was making things worse here on the dashboard page as the 500px side bar make it move under the content.

I changed the rule to only apply for screen widths >= @md-breakpoint

(I didn't test by rebuilding the extension so there might be dragons)