### PR TITLE
Fix comment width on larger breakpoints

### DIFF
--- a/src/github-inject.less
+++ b/src/github-inject.less
@@ -93,7 +93,7 @@ table.files td.content {
         }
 
         & .comment-holder {
-            max-width: none !important;
+            .max-width(140px);
         }
 
         & .timeline-comment {


### PR DESCRIPTION
After a lot of recent changes to the GH UI for reviewing PRs etc., the comments are way too wide. This fixes it :sparkles: 