### PR TITLE
Adapted to GitHub and Gist's new interface 

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,7 +25,9 @@ gulp.task('clean', function () {
 gulp.task('styles', function () {
   return gulp.src('./src/*.less')
     .pipe(sourcemaps.init())
-    .pipe(less())
+    .pipe(less({
+      strictMath: 'on'
+    }))
     .pipe(cleanCSS())
     .pipe(sourcemaps.write())
     .pipe(rename({ suffix: '.min' }))

--- a/src/gist-inject.less
+++ b/src/gist-inject.less
@@ -9,8 +9,12 @@
         max-width: @breakpoint - @width !important
     }
 
+    .container-xl {
+        max-width: none !important;
+    }
+
     .container-lg {
-        .max-width(120px);
+        max-width: none !important;
     }
 
     .container {

--- a/src/gist-inject.less
+++ b/src/gist-inject.less
@@ -14,7 +14,7 @@
     }
 
     .container-lg {
-        max-width: none !important;
+        .max-width(120px);
     }
 
     .container {

--- a/src/github-inject.less
+++ b/src/github-inject.less
@@ -12,6 +12,9 @@
     .range-editor .fork-suggester .css-truncate-target {
         .max-width(1120px);
     }
+    .container-xl {
+        max-width: none !important;
+    }
     .container-lg {
         .max-width(120px);
     }
@@ -120,10 +123,6 @@
     .capped-card {
         margin-right: 10px !important;
         margin-left: 10px !important;
-    }
-    .css-truncate.css-truncate-target {
-        white-space: normal !important;
-        word-wrap: break-word !important;
     }
     table.files td.content {
         width: inherit !important;


### PR DESCRIPTION
Hello, I've noticed that GitHub's experimental new UI has been applied to all users, and it breaks github.expandinizr plugin. See https://github.com/thecodejunkie/github.expandinizr/issues/75 .

So here's my fix, It should work well with GitHub and Gist's new interface.

Screenshots:

![image](https://user-images.githubusercontent.com/29622423/85491252-c8e89980-b605-11ea-80f1-a951728216c7.png)
![image](https://user-images.githubusercontent.com/29622423/85491278-d30a9800-b605-11ea-9018-25dbe840b9ef.png)
> ↑Before

![image](https://user-images.githubusercontent.com/29622423/85491324-e6b5fe80-b605-11ea-9ceb-16f45c9a5750.png)
![image](https://user-images.githubusercontent.com/29622423/85491302-db62d300-b605-11ea-936f-abaf82303d28.png)
> ↑After
