### PR TITLE
Remove 'tabs' permission

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,7 +10,6 @@
     "128": "icons/icon128.png"
   },
   "permissions": [
-    "tabs",
     "storage",
     "activeTab",
     "declarativeContent",


### PR DESCRIPTION
Doesn't look like we need it anymore. @thecodejunkie We really need to get this out the door. The GitHub experience is degrading by the minute without this extension.